### PR TITLE
Fix typo with information and remove useless link to the plugins guide

### DIFF
--- a/content/docs/admin/users/index.md
+++ b/content/docs/admin/users/index.md
@@ -19,7 +19,7 @@ To access the Users administration, click on **Admin** in the navigation bar, an
 
 {{< img src="users-table.png" alt="Users table" >}}
 
-To create a user, click on the **Create** button and fill the user informations:
+To create a user, click on the **Create** button and fill the user information:
 
 - **Username**: must match user Github username in order to connect and *cannot be updated*.
 - **Firstname** | **Lastname** | **Email**: explicit

--- a/content/docs/user/about/index.md
+++ b/content/docs/user/about/index.md
@@ -12,6 +12,6 @@ menu:
 weight: 080
 ---
 
-You can click on the About icon in the navigation bar to display the informations about your FrontLine version and about your license.
+You can click on the About icon in the navigation bar to display the information about your FrontLine version and about your license.
 
 {{< img src="about.png" alt="About" >}}

--- a/content/docs/user/help/index.md
+++ b/content/docs/user/help/index.md
@@ -20,6 +20,6 @@ You can click on the Documentation icon in the navigation bar on the bottom left
 ## Plugins Download
 
 If you want to download one of your official FrontLine plugin, please click on the Plugins icon in the navigation bar.
-For more informations about the plugins, please refer to our plugins guide, go the the [plugins guide](https://gatling.io/docs/frontline/FrontLine-Plugins-Guide.pdf).
+For more information about the plugins, please refer to the **Plugins** section of this site.
 
 {{< img src="plugins-modal.png" alt="Plugins modal" >}}

--- a/content/docs/user/overview/index.md
+++ b/content/docs/user/overview/index.md
@@ -18,7 +18,7 @@ Once you are logged in, you are now able to navigate using the FrontLine navigat
 FrontLine is composed of:
 
 - **Profile**, manage account settings
-- **Users**, manage users informations, teams and permissions - *accessible to system admin*
+- **Users**, manage users information, teams and permissions - *accessible to system admin*
 - **Teams**, manage teams - *accessible to system admin*
 - **API Tokens**, manage token to access the API - *accessible to system admin*
 - **Artifacts**, manage simulations artifacts - *accessible from test admin*

--- a/content/docs/user/profile/index.md
+++ b/content/docs/user/profile/index.md
@@ -24,6 +24,6 @@ The information displayed are the following:
 - Mail address
 - Different roles
 
-To update your profile, modify the fields you want to change, then click on the button **Update your informations**.
+To update your profile, modify the fields you want to change, then click on the button **Update your information**.
 
 You can't update your username here. You need to ask a System Admin to change your roles on the **Users Admin** page.

--- a/content/docs/user/reports/index.md
+++ b/content/docs/user/reports/index.md
@@ -38,7 +38,7 @@ The navigation bar enable you to choose the simulation time range.
 ### Timeline
 
 The timeline contains metrics of the full run providing an overview of the run.
-Global informations are available such as the resolution and the simulation name.
+Global information are available such as the resolution and the simulation name.
 
 The resolution indicates the number of seconds per data point in the graph.
 


### PR DESCRIPTION
Modifications:
- Information doesn't take an s
- removed useless link to the pdf plugins guide