### PR TITLE
Improve tutorials, close MISC-72

### DIFF
--- a/content/tutorials/_includes/download_samples.md
+++ b/content/tutorials/_includes/download_samples.md
@@ -1,5 +1,9 @@
 ## Download the sample Gatling simulation
 
-Once you've connected to FrontLine, you'll be redirected to the simulations page. For this tutorial, we'll use the samples included with FrontLine. Click on the Download samples button.
+Once you've connected to FrontLine, you'll be redirected to the simulations page.
+For this tutorial, we'll use the samples included with FrontLine.
+Click on the Download samples button.
 
 {{< img src="download_samples.png" alt="Download samples" >}}
+
+

--- a/content/tutorials/_includes/introduction.md
+++ b/content/tutorials/_includes/introduction.md
@@ -1,5 +1,6 @@
 In this tutorial, we'll describe every step you need to take in order to have a working basic configuration on FrontLine.
 
-Once you connect to the instance provided by Gatling Corp, you'll see this page. You need to signup with the Github account you provided Gatling Corp.
+Once you connect to the instance provided by Gatling Corp, you'll see this page.
+You need to signup with the Github account you provided Gatling Corp.
 
 {{< img src="login.png" alt="Login" >}}

--- a/content/tutorials/bundle/index.md
+++ b/content/tutorials/bundle/index.md
@@ -13,21 +13,29 @@ contributors: []
 
 {{< include introduction.md >}}
 
-## Create an artifact
-
 There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run. We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
 
 In this tutorial, we'll use the Gatling bundle. Make sure that you have a JDK 8 or 11 installed on your computer.
 
-Download the latest version of the Gatling bundle here: https://gatling.io/open-source/start-testing and extract the archive.
+## Download the zip bundle
+[`Click here to download the latest version of the Gatling bundle`](https://gatling.io/open-source/start-testing) and extract the archive.
 
-On a Windows computer: copy this [`artifact.bat`](https://raw.githubusercontent.com/gatling/gatling/master/gatling-bundle/src/universal/bin/artifact.bat) file in the `bin` directory of the decompressed archive. On a Linux or MacOs computer: copy this [`artifact.sh`](https://raw.githubusercontent.com/gatling/gatling/master/gatling-bundle/src/universal/bin/artifact.sh) file instead in the `bin` directory of the decompressed archive.
+## Download and copy the extra script
+
+* On Windows: [`click here to download this artifact.bat`](https://raw.githubusercontent.com/gatling/gatling/master/gatling-bundle/src/universal/bin/artifact.bat).
+* On Linux or MacOS: [`click here to download this artifact.sh`](https://raw.githubusercontent.com/gatling/gatling/master/gatling-bundle/src/universal/bin/artifact.sh).
+
+Copy this file in the `bin` directory of the decompressed archive.
 
 {{< img src="bundle.png" alt="Launch artifact.bat" >}}
+
+## Generate the artifact
 
 Run the `artifact.bat` or `artifact.sh` file, Gatling will start creating our first artifact!
 
 {{< include upload.md "target/artifact.jar" >}}
+
+## Upload the artifact
 
 Upload it to FrontLine, either by drag-and-dropping it to the modal, or by clicking on the modal to open the file manager.
 

--- a/content/tutorials/gradle/index.md
+++ b/content/tutorials/gradle/index.md
@@ -12,17 +12,27 @@ contributors: []
 
 {{< include introduction.md >}}
 
+There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run.
+We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
+
+In this tutorial, we'll use the Gradle build tool, so make sure you have Gradle configured.
+We'll use Gradle from the terminal, but you can also do it easily with an IDE like IntelliJ.
+
 {{< include download_samples.md >}}
 
-## Create an artifact
+Extract the archive, then navigate to the gradle folder.
+This folder contains a basic Gatling simulation which can be used with FrontLine.
 
-There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run. We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
+## Check the Gradle build configuration
 
-In this tutorial, we'll use the Gradle build tool, so make sure you have Gradle configured. We'll use Gradle from the terminal, but you can also do it easily with an IDE like IntelliJ.
+You can check in the `build.gradle` files that this project uses a special `io.gatling.frontline.gradle` plugin to generate the artifact in the proper format.
 
-Extract the archive, then navigate to the gradle folder and open a terminal there. This folder contains a basic Gatling simulation which can be used with FrontLine.
+If you have some existing projects you want to use, you'll have to configure this plugin there too.
+If so, please have a look at the [Reference Documentation](/docs/user/artifact_gen/#gradle-project) for more information.
 
-Execute the following command to create an artifact:
+## Generate the artifact
+
+Open a terminal in the gradle folder and execute the following command to create an artifact:
 
 ```shell
 gradle frontLineJar
@@ -30,7 +40,8 @@ gradle frontLineJar
 
 {{< img src="gradle_command.png" alt="Maven command" >}}
 
-Gradle will download the necessary dependencies and package our simulation. That's it, we created our first Gatling artifact!
+Gradle will download the necessary dependencies and package our simulation.
+That's it, we created our first Gatling artifact!
 
 {{< include upload.md "frontline-samples/gradle/build/libs/gradle.jar" >}}
 
@@ -38,7 +49,8 @@ Upload it to FrontLine, either by drag-and-dropping it to the modal, or by click
 
 {{< img src="choose_artifact.png" alt="Choose the generated artifact" >}}
 
-We now have to click on the Upload button to upload it to FrontLine. After a few seconds, the upload will be complete, and our artifact will be successfully ready to use!
+We now have to click on the Upload button to upload it to FrontLine.
+After a few seconds, the upload will be complete, and our artifact will be successfully ready to use!
 
 {{< img src="upload.png" alt="Start the upload" >}}
 

--- a/content/tutorials/maven/index.md
+++ b/content/tutorials/maven/index.md
@@ -12,17 +12,27 @@ contributors: []
 
 {{< include introduction.md >}}
 
+There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run.
+We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
+
+In this tutorial, we'll use the Maven build tool, so make sure you have Maven configured.
+We'll use Maven from the terminal, but you can also do it easily with an IDE like IntelliJ.
+
 {{< include download_samples.md >}}
 
-## Create an artifact
+Extract the archive, then navigate to the maven folder.
+This folder contains a basic Gatling simulation which can be used with FrontLine.
 
-There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run. We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
+## Check the Maven build configuration
 
-In this tutorial, we'll use the Maven build tool, so make sure you have Maven configured. We'll use Maven from the terminal, but you can also do it easily with an IDE like IntelliJ.
+You can check in the `pom.xml` file that this project uses a special `frontline-maven-plugin` plugin to generate the artifact in the proper format.
 
-Extract the archive, then navigate to the maven folder and open a terminal there. This folder contains a basic Gatling simulation which can be used with FrontLine.
+If you have some existing projects you want to use, you'll have to configure this plugin there too.
+If so, please have a look at the [Reference Documentation](/docs/user/artifact_gen/#maven-project) for more information.
 
-Execute the following command to create an artifact:
+## Generate the artifact
+
+Open a terminal in the maven folder and execute the following command to create an artifact:
 
 ```shell
 mvn clean package -DskipTests
@@ -30,7 +40,8 @@ mvn clean package -DskipTests
 
 {{< img src="maven_command.png" alt="Maven command" >}}
 
-Maven will download the necessary dependencies and package our simulation. That's it, we created our first Gatling artifact!
+Maven will download the necessary dependencies and package our simulation.
+That's it, we created our first Gatling artifact!
 
 {{< include upload.md "frontline-samples/maven/target/maven-sample-1.0.0-shaded.jar" >}}
 
@@ -38,7 +49,8 @@ Upload it to FrontLine, either by drag-and-dropping it to the modal, or by click
 
 {{< img src="choose_artifact.png" alt="Choose the generated artifact" >}}
 
-We now have to click on the Upload button to upload it to FrontLine. After a few seconds, the upload will be complete, and our artifact will be successfully ready to use!
+We now have to click on the Upload button to upload it to FrontLine.
+After a few seconds, the upload will be complete, and our artifact will be successfully ready to use!
 
 {{< img src="upload.png" alt="Start the upload" >}}
 

--- a/content/tutorials/sbt/index.md
+++ b/content/tutorials/sbt/index.md
@@ -12,17 +12,27 @@ contributors: []
 
 {{< include introduction.md >}}
 
+There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run.
+We can use either a build tool (Maven, sbt, Gradle) or the Gatling bundle.
+
+In this tutorial, we'll use the sbt build tool, so make sure you have sbt configured and Java installed.
+We'll use sbt from the terminal, but you can also do it easily with an IDE like IntelliJ.
+
 {{< include download_samples.md >}}
 
-## Create an artifact
+Extract the archive, then navigate to the sbt folder.
+This folder contains a basic Gatling simulation which can be used with FrontLine.
 
-There are multiple ways to create a Gatling artifact, which will be used by FrontLine to launch a run. We can use either a build tool (Maven, sbt, Gradle) or the Gatling bundle.
+## Check the sbt build configuration
 
-In this tutorial, we'll use the sbt build tool, so make sure you have sbt configured and Java installed. We'll use sbt from the terminal, but you can also do it easily with an IDE like IntelliJ.
+You can check in the `build.sbt` and `project/plugins.sbt` files that this project uses a special `sbt-frontline` plugin to generate the artifact in the proper format.
 
-Extract the archive, then navigate to the sbt folder and open a terminal there. This folder contains a basic Gatling simulation which can be used with FrontLine.
+If you have some existing projects you want to use, you'll have to configure this plugin there too.
+If so, please have a look at the [Reference Documentation](/docs/user/artifact_gen/#maven-project) for more information.
 
-Execute the following command to create an artifact:
+## Generate the artifact
+
+Open a terminal in the sbt folder and execute the following command to create an artifact:
 
 ```shell
 sbt test:assembly
@@ -30,7 +40,8 @@ sbt test:assembly
 
 {{< img src="sbt_command.png" alt="sbt command" >}}
 
-sbt will download the necessary dependencies and package our simulation. That's it, we created our first Gatling artifact!
+sbt will download the necessary dependencies and package our simulation.
+That's it, we created our first Gatling artifact!
 
 {{< include upload.md "frontline-samples/sbt/target/sbt-frontline-1.0.0.jar" >}}
 
@@ -38,7 +49,8 @@ Upload it to FrontLine, either by drag-and-dropping it to the modal, or by click
 
 {{< img src="choose_artifact.png" alt="Choose the generated artifact" >}}
 
-We now have to click on the Upload button to upload it to FrontLine. After a few seconds, the upload will be complete, and our artifact will be successfully ready to use!
+We now have to click on the Upload button to upload it to FrontLine.
+After a few seconds, the upload will be complete, and our artifact will be successfully ready to use!
 
 {{< img src="upload.png" alt="Start the upload" >}}
 


### PR DESCRIPTION
Motivation:

* Users don't understand they have to download the artifact script file and that the artifact word is a link.
* Tutorials lack steps, it's one long block and it's easy to miss a step
* In maven, gradle and sbt tutorials, users are not made aware of the extra plugins they have to use with their existing projects.

Modifications:

* Use the `click here` words for calls to action
* Use the download word explicitly
* Split long blocks into sections
* Add a section for discovering the build plugins

Result:

Hopefully better UX