### PR TITLE
Set anchors on tutorials titles and fix author `by` when there's none, closes MISC-74, closes MISC-75

### DIFF
--- a/layouts/partials/main/tutorials-meta.html
+++ b/layouts/partials/main/tutorials-meta.html
@@ -1,1 +1,15 @@
-<p><small>Posted {{ .PublishDate.Format "January 2, 2006" }} by {{ if .Params.contributors -}}{{ range $index, $contributor := .Params.contributors }}{{ if gt $index 0 }} and {{ end }}<a class="stretched-link position-relative" href="{{ "/contributors/" | absURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}&nbsp;&hyphen;&nbsp;<strong>{{ .ReadingTime -}}&nbsp;min read</strong></small><p>
+<p>
+  <small>
+    Posted {{ .PublishDate.Format "January 2, 2006" }}
+    {{ if .Params.contributors -}}
+      by
+      {{ range $index, $contributor := .Params.contributors }}
+        {{ if gt $index 0 }} and {{ end }}
+        <a class="stretched-link position-relative" href="{{ "/contributors/" | absURL }}{{ . | urlize }}/">
+          {{ . }}
+        </a>
+      {{ end -}}
+    {{ end -}}&nbsp;&hyphen;&nbsp;
+    <strong>{{ .ReadingTime -}}&nbsp;min read</strong>
+  </small>
+<p>

--- a/layouts/tutorials/single.html
+++ b/layouts/tutorials/single.html
@@ -1,14 +1,14 @@
 {{ define "main" }}
-<div class="row justify-content-center">
-  <div class="col-md-12 col-lg-10 col-xl-8">
-    <article>
-      <div class="tutorials-header">
-        <h1>{{ .Title }}</h1>
-        {{ partial "main/tutorials-meta.html" . }}
-      </div>
-      <p class="lead">{{ .Params.lead | safeHTML }}</p>
-      {{ .Content }}
-    </article>
-  </div>
+<div class="row flex-xl-nowrap">
+  <article>
+    <div class="tutorials-header">
+      <h1>{{ .Title }}</h1>
+      {{ partial "main/tutorials-meta.html" . }}
+    </div>
+    <p class="lead">{{ .Params.lead | safeHTML }}</p>
+    <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+      {{ partial "main/headline-hash.html" .Content }}
+    </main>
+  </article>
 </div>
 {{ end }}


### PR DESCRIPTION
### Set anchors on tutorials titles, closes MISC-74

**Motivation:**
Provide users a link pointing to the relevant section

**Modification:**
* Use partial headline-hash for content
* Add wrapping div with class `docs-content` for anchor css

---

### Fix authors `by` showing when there's none, closes MISC-75
