### PR TITLE
Tutorials: center image, navigator and table of contents, closes MISC-77, closes MISC-78

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -155,6 +155,13 @@ body {
 .docs-content {
   padding-bottom: 3rem;
   order: 1;
+
+  figure {
+    display: flex;
+    & > a {
+      margin: auto;
+    }
+  }
 }
 
 .docs-navigation {

--- a/content/tutorials/bundle/index.md
+++ b/content/tutorials/bundle/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting started with the Gatling bundle"
+title: "Bundle"
 slug: "getting-started-with-gatling-bundle"
 description: "Learning how to setup FrontLine Cloud using the Gatling bundle"
 lead: ""
@@ -7,6 +7,9 @@ date: 2021-03-19T17:03:31+01:00
 lastmod: 2021-03-19T17:03:31+01:00
 draft: false
 images: []
+menu:
+  tutorials:
+    parent: "Getting started"
 weight: 50
 contributors: []
 ---

--- a/content/tutorials/gradle/index.md
+++ b/content/tutorials/gradle/index.md
@@ -1,11 +1,14 @@
 ---
-title: "Getting started with Gradle"
+title: "Gradle"
 description: "Learning how to setup FrontLine Cloud using Gradle"
 lead: ""
 date: 2021-03-19T17:03:31+01:00
 lastmod: 2021-03-19T17:03:31+01:00
 draft: false
 images: []
+menu:
+  tutorials:
+    parent: "Getting started"
 weight: 50
 contributors: []
 ---

--- a/content/tutorials/maven/index.md
+++ b/content/tutorials/maven/index.md
@@ -1,11 +1,14 @@
 ---
-title: "Getting started with Maven"
+title: "Maven"
 description: "Learning how to setup FrontLine Cloud using Maven"
 lead: ""
 date: 2021-03-19T17:03:31+01:00
 lastmod: 2021-03-19T17:03:31+01:00
 draft: false
 images: []
+menu:
+  tutorials:
+    parent: "Getting started"
 weight: 50
 contributors: []
 ---

--- a/content/tutorials/sbt/index.md
+++ b/content/tutorials/sbt/index.md
@@ -1,11 +1,14 @@
 ---
-title: "Getting started with sbt"
+title: "sbt"
 description: "Learning how to setup FrontLine using sbt"
 lead: ""
 date: 2021-03-19T17:03:31+01:00
 lastmod: 2021-03-19T17:03:31+01:00
 draft: false
 images: []
+menu:
+  tutorials:
+    parent: "Getting started"
 weight: 50
 contributors: []
 ---

--- a/layouts/partials/sidebar/tutorials-menu.html
+++ b/layouts/partials/sidebar/tutorials-menu.html
@@ -1,0 +1,13 @@
+{{ $currentPage := . -}}
+{{ range .Site.Menus.tutorials -}}
+  <h3>{{ .Name }}</h3>
+  {{ if .HasChildren -}}
+  <ul class="list-unstyled">
+    {{ range .Children -}}
+      {{- $active := or ($currentPage.IsMenuCurrent "tutorials" .) ($currentPage.HasMenuCurrent "tutorials" .) -}}
+      {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
+      <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+    {{ end -}}
+  </ul>
+  {{ end -}}
+{{ end -}}

--- a/layouts/tutorials/single.html
+++ b/layouts/tutorials/single.html
@@ -1,14 +1,26 @@
 {{ define "main" }}
 <div class="row flex-xl-nowrap">
-  <article>
+  <div class="col-lg-5 col-xl-4 docs-sidebar">
+    <nav class="docs-links" aria-label="Main navigation">
+      {{ partial "sidebar/tutorials-menu.html" . }}
+    </nav>
+  </div>
+  {{ if ne .Params.toc false -}}
+  <nav class="docs-toc d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
+    {{ partial "sidebar/docs-toc.html" . }}
+  </nav>
+  {{ end -}}
+  {{ if .Params.toc -}}
+  <main class="docs-content col-lg-11 col-xl-9">
+  {{ else -}}
+  <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+  {{ end -}}
     <div class="tutorials-header">
       <h1>{{ .Title }}</h1>
       {{ partial "main/tutorials-meta.html" . }}
     </div>
     <p class="lead">{{ .Params.lead | safeHTML }}</p>
-    <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
-      {{ partial "main/headline-hash.html" .Content }}
-    </main>
-  </article>
+    {{ partial "main/headline-hash.html" .Content }}
+  </main>
 </div>
 {{ end }}


### PR DESCRIPTION
### Add tutorials table of content and navigator, closes MISC-77
---
### Align tutorials image to center, closes MISC-78

![image](https://user-images.githubusercontent.com/56551877/113162246-1df8b200-920d-11eb-85fe-05ea56d233f1.png)
