### PR TITLE
Add a menutitle parameter for tutorials, close MISC-79

### DIFF
--- a/content/tutorials/bundle/index.md
+++ b/content/tutorials/bundle/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Bundle"
+title: "Getting started with the Gatling bundle"
+menutitle: "Bundle"
 slug: "getting-started-with-gatling-bundle"
 description: "Learning how to setup FrontLine Cloud using the Gatling bundle"
 lead: ""

--- a/content/tutorials/gradle/index.md
+++ b/content/tutorials/gradle/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Gradle"
+title: "Getting started with Gradle"
+menutitle: "Gradle"
 description: "Learning how to setup FrontLine Cloud using Gradle"
 lead: ""
 date: 2021-03-19T17:03:31+01:00

--- a/content/tutorials/maven/index.md
+++ b/content/tutorials/maven/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Maven"
+title: "Getting started with Maven"
+menutitle: "Maven"
 description: "Learning how to setup FrontLine Cloud using Maven"
 lead: ""
 date: 2021-03-19T17:03:31+01:00

--- a/content/tutorials/sbt/index.md
+++ b/content/tutorials/sbt/index.md
@@ -1,5 +1,6 @@
 ---
-title: "sbt"
+title: "Getting started with sbt"
+menutitle: "sbt"
 description: "Learning how to setup FrontLine using sbt"
 lead: ""
 date: 2021-03-19T17:03:31+01:00

--- a/layouts/partials/sidebar/tutorials-menu.html
+++ b/layouts/partials/sidebar/tutorials-menu.html
@@ -3,11 +3,17 @@
   <h3>{{ .Name }}</h3>
   {{ if .HasChildren -}}
   <ul class="list-unstyled">
-    {{ range .Children -}}
+    {{- range .Children -}}
       {{- $active := or ($currentPage.IsMenuCurrent "tutorials" .) ($currentPage.HasMenuCurrent "tutorials" .) -}}
       {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-      <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
-    {{ end -}}
+      {{- $menutitle := "" -}}
+      {{- if .Page.Params.menutitle -}}
+          {{- $menutitle = .Page.Params.menutitle -}}
+      {{- else -}}
+          {{- $menutitle = .Name -}}
+      {{- end -}}
+      <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}">{{ $menutitle }}</a></li>
+    {{- end -}}
   </ul>
   {{ end -}}
 {{ end -}}


### PR DESCRIPTION
Motivation:

- Changing tutorials titles made it hard to figure out what tutorials are all about

Modification:

- Added a menutitle front matter parameter
- Used it in the left menu partial, with a fallback on real title if
  undefined