### PR TITLE
Fix next and previous button not linking the correct pages, closes MISC-88

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ npm run create docs/user/test/test.md
 ```
 
 Make sure you have draft set to false in the page metadata, otherwise the page you created won't be displayed.
+
+### Page weight
+
+The weight indicates which page comes first in the sidebar. We use this system: SBXX0 where:
+- S: corresponds to the sidenav section number (begins at 1)
+- B: corresponds to the branch number (set to 0 if not in a branch)
+- XX: place inside the current group of pages (begins at 1)

--- a/content/docs/admin/api-tokens/index.md
+++ b/content/docs/admin/api-tokens/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "admin"
-weight: 040
+weight: 20030
 ---
 
 ## Managing API Tokens

--- a/content/docs/admin/teams/index.md
+++ b/content/docs/admin/teams/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "admin"
-weight: 020
+weight: 20020
 ---
 
 ## Managing Teams

--- a/content/docs/admin/users/index.md
+++ b/content/docs/admin/users/index.md
@@ -9,9 +9,8 @@ images: []
 menu:
   docs:
     parent: "admin"
-weight: 010
+weight: 20010
 ---
-
 
 ## Managing Users
 

--- a/content/docs/plugins/bamboo/index.md
+++ b/content/docs/plugins/bamboo/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "plugins"
-weight: 030
+weight: 30030
 ---
 
 ## Purpose of this plugin

--- a/content/docs/plugins/grafana/index.md
+++ b/content/docs/plugins/grafana/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "plugins"
-weight: 050
+weight: 30050
 ---
 
 ## Requirements

--- a/content/docs/plugins/jenkins/index.md
+++ b/content/docs/plugins/jenkins/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "plugins"
-weight: 010
+weight: 30010
 ---
 
 ## Purpose of this plugin

--- a/content/docs/plugins/script/index.md
+++ b/content/docs/plugins/script/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "plugins"
-weight: 040
+weight: 30040
 ---
 
 ## Purpose of this script

--- a/content/docs/plugins/teamcity/index.md
+++ b/content/docs/plugins/teamcity/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "plugins"
-weight: 020
+weight: 30020
 ---
 
 ## Purpose of this plugin

--- a/content/docs/user/about/index.md
+++ b/content/docs/user/about/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 080
+weight: 10100
 ---
 
 You can click on the About icon in the navigation bar to display the information about your FrontLine version and about your license.

--- a/content/docs/user/api/index.md
+++ b/content/docs/user/api/index.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 070
+weight: 10090
 ---
 
 The FrontLine API server also exposes a public API that you can use to trigger runs or fetch run results and metrics.

--- a/content/docs/user/artifact_conf/index.md
+++ b/content/docs/user/artifact_conf/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 050
+weight: 10050
 ---
 
 ## Managing

--- a/content/docs/user/artifact_gen/index.md
+++ b/content/docs/user/artifact_gen/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 040
+weight: 10040
 ---
 
 ## Generating Artifacts for FrontLine

--- a/content/docs/user/help/index.md
+++ b/content/docs/user/help/index.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 090
+weight: 10110
 ---
 
 ## Documentation

--- a/content/docs/user/login/index.md
+++ b/content/docs/user/login/index.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 010
+weight: 10010
 ---
 
 In order to log in, you need an account with the same username as your GitHub account.

--- a/content/docs/user/overview/index.md
+++ b/content/docs/user/overview/index.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 020
+weight: 10020
 ---
 
 Once you are logged in, you are now able to navigate using the FrontLine navigation bar on the left side.

--- a/content/docs/user/profile/index.md
+++ b/content/docs/user/profile/index.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 030
+weight: 10030
 ---
 
 ## Accessing your profile

--- a/content/docs/user/reports/index.md
+++ b/content/docs/user/reports/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 062
+weight: 10080
 ---
 
 ## Reports

--- a/content/docs/user/simulations/index.md
+++ b/content/docs/user/simulations/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 060
+weight: 10060
 ---
 
 ## Managing Simulations

--- a/content/docs/user/trends/index.md
+++ b/content/docs/user/trends/index.md
@@ -9,7 +9,7 @@ images: []
 menu:
   docs:
     parent: "user"
-weight: 061
+weight: 10070
 ---
 
 ## Run / Trends


### PR DESCRIPTION
Motivation:
- previous and next buttons are not linking the correct pages

Modifications:
- Fixed the weight system: weight is compared globally, and not within a section
- added a part about the weight in the README