### PR TITLE
Fix titles missing in the tutorials table of contents, closes MISC-81

### DIFF
--- a/content/tutorials/_includes/download_samples.md
+++ b/content/tutorials/_includes/download_samples.md
@@ -1,5 +1,3 @@
-## Download the sample Gatling simulation
-
 Once you've connected to FrontLine, you'll be redirected to the simulations page.
 For this tutorial, we'll use the samples included with FrontLine.
 Click on the Download samples button.

--- a/content/tutorials/_includes/resources.md
+++ b/content/tutorials/_includes/resources.md
@@ -1,0 +1,5 @@
+You have successfully started load testing, you can read our documentation if you need more information about our product:
+
+- [FrontLine documentation]({{< ref "/" >}})
+- [Documentation about the creation of an artifact]({{< ref "docs/user/reports" >}})
+- [Documentation about how to use the FrontLine reports]({{< ref "docs/user/reports" >}})

--- a/content/tutorials/_includes/run.md
+++ b/content/tutorials/_includes/run.md
@@ -1,0 +1,13 @@
+We're now ready to start load testing on FrontLine. To start the simulation we created previously, click on the {{< icon play >}} icon.
+
+{{< img src="start_simulation.png" alt="Start the simulation" >}}
+
+You can see the status of the simulation in the "Status" column, and the logs by clicking on the {{< icon file-alt >}} button.
+
+{{< img src="simulation_ongoing.png" alt="Simulation status" >}}
+
+You also have access to advanced metrics about your run, even while the simulation is still running. Click on the {{< icon chart-area >}} button to see the reports.
+
+{{< img src="reports.png" alt="FrontLine Reports" >}}
+
+You will find here every information you may need to analyze your run. Take some time to interact with the graphs and change tabs.

--- a/content/tutorials/_includes/simulation_1.md
+++ b/content/tutorials/_includes/simulation_1.md
@@ -1,5 +1,3 @@
-## Create a FrontLine simulation
-
 Now that we've created our artifact on FrontLine, it is time to create a simulation. A simulation is a configuration of a Gatling test on FrontLine.
 
 Let's get back to the main page by clicking on the Gatling icon of the navbar.

--- a/content/tutorials/_includes/simulation_2.md
+++ b/content/tutorials/_includes/simulation_2.md
@@ -7,27 +7,3 @@ In this last step, you'll be asked where you want the injection to take place. W
 {{< img src="create_simulation_step_3.png" alt="Injection configuration" >}}
 
 That's it, we created our first simulation on FrontLine!
-
-## Start load testing!
-
-We're now ready to start load testing on FrontLine. To start the simulation we created previously, click on the {{< icon play >}} icon.
-
-{{< img src="start_simulation.png" alt="Start the simulation" >}}
-
-You can see the status of the simulation in the "Status" column, and the logs by clicking on the {{< icon file-alt >}} button.
-
-{{< img src="simulation_ongoing.png" alt="Simulation status" >}}
-
-You also have access to advanced metrics about your run, even while the simulation is still running. Click on the {{< icon chart-area >}} button to see the reports.
-
-{{< img src="reports.png" alt="FrontLine Reports" >}}
-
-You will find here every information you may need to analyze your run. Take some time to interact with the graphs and change tabs.
-
-## Additional resources
-
-You have successfully started load testing, you can read our documentation if you need more information about our product:
-
-- [FrontLine documentation]({{< ref "/" >}})
-- [Documentation about the creation of an artifact]({{< ref "docs/user/reports" >}})
-- [Documentation about how to use the FrontLine reports]({{< ref "docs/user/reports" >}})

--- a/content/tutorials/_includes/upload.md
+++ b/content/tutorials/_includes/upload.md
@@ -1,5 +1,3 @@
-## Upload the artifact to FrontLine
-
 Let's get back to FrontLine. To navigate to the artifacts page, click on the {{< icon archive >}} icon on the Sidenav (navigation bar on the left of the screen).
 
 {{< img src="artifact_navigation.png" alt="Sidenav navigation" >}}

--- a/content/tutorials/bundle/index.md
+++ b/content/tutorials/bundle/index.md
@@ -37,6 +37,8 @@ Copy this file in the `bin` directory of the decompressed archive.
 
 Run the `artifact.bat` or `artifact.sh` file, Gatling will start creating our first artifact!
 
+## Upload the artifact to FrontLine
+
 {{< include upload.md "target/artifact.jar" >}}
 
 ## Upload the artifact
@@ -49,9 +51,19 @@ We now have to click on the Upload button to upload it to FrontLine. After a few
 
 {{< img src="upload.png" alt="Start the upload" >}}
 
+## Create a FrontLine simulation
+
 {{< include simulation_1.md "computerdatabase.BasicSimulation" >}}
 
 {{< img src="create_simulation_step_1.png" alt="General configuration" >}}
 
 {{< include simulation_2.md "frontline.sample.BasicSimulation" >}}
+
+## Start load testing!
+
+{{< include run.md >}}
+
+## Additional resources
+
+{{< include resources.md >}}
 

--- a/content/tutorials/gradle/index.md
+++ b/content/tutorials/gradle/index.md
@@ -22,6 +22,8 @@ We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
 In this tutorial, we'll use the Gradle build tool, so make sure you have Gradle configured.
 We'll use Gradle from the terminal, but you can also do it easily with an IDE like IntelliJ.
 
+## Download the sample Gatling simulation
+
 {{< include download_samples.md >}}
 
 Extract the archive, then navigate to the gradle folder.
@@ -47,6 +49,8 @@ gradle frontLineJar
 Gradle will download the necessary dependencies and package our simulation.
 That's it, we created our first Gatling artifact!
 
+## Upload the artifact to FrontLine
+
 {{< include upload.md "frontline-samples/gradle/build/libs/gradle.jar" >}}
 
 Upload it to FrontLine, either by drag-and-dropping it to the modal, or by clicking on the modal to open the file manager.
@@ -58,8 +62,18 @@ After a few seconds, the upload will be complete, and our artifact will be succe
 
 {{< img src="upload.png" alt="Start the upload" >}}
 
+## Create a FrontLine simulation
+
 {{< include simulation_1.md "frontline.sample.BasicSimulation" >}}
 
 {{< img src="create_simulation_step_1.png" alt="General configuration" >}}
 
 {{< include simulation_2.md "frontline.sample.BasicSimulation" >}}
+
+## Start load testing!
+
+{{< include run.md >}}
+
+## Additional resources
+
+{{< include resources.md >}}

--- a/content/tutorials/maven/index.md
+++ b/content/tutorials/maven/index.md
@@ -22,6 +22,8 @@ We can use either a build tool (Maven, Sbt, Gradle) or the Gatling bundle.
 In this tutorial, we'll use the Maven build tool, so make sure you have Maven configured.
 We'll use Maven from the terminal, but you can also do it easily with an IDE like IntelliJ.
 
+## Download the sample Gatling simulation
+
 {{< include download_samples.md >}}
 
 Extract the archive, then navigate to the maven folder.
@@ -47,6 +49,8 @@ mvn clean package -DskipTests
 Maven will download the necessary dependencies and package our simulation.
 That's it, we created our first Gatling artifact!
 
+## Upload the artifact to FrontLine
+
 {{< include upload.md "frontline-samples/maven/target/maven-sample-1.0.0-shaded.jar" >}}
 
 Upload it to FrontLine, either by drag-and-dropping it to the modal, or by clicking on the modal to open the file manager.
@@ -58,8 +62,18 @@ After a few seconds, the upload will be complete, and our artifact will be succe
 
 {{< img src="upload.png" alt="Start the upload" >}}
 
+## Create a FrontLine simulation
+
 {{< include simulation_1.md "frontline.sample.BasicSimulation" >}}
 
 {{< img src="create_simulation_step_1.png" alt="General configuration" >}}
 
 {{< include simulation_2.md "frontline.sample.BasicSimulation" >}}
+
+## Start load testing!
+
+{{< include run.md >}}
+
+## Additional resources
+
+{{< include resources.md >}}

--- a/content/tutorials/sbt/index.md
+++ b/content/tutorials/sbt/index.md
@@ -22,6 +22,8 @@ We can use either a build tool (Maven, sbt, Gradle) or the Gatling bundle.
 In this tutorial, we'll use the sbt build tool, so make sure you have sbt configured and Java installed.
 We'll use sbt from the terminal, but you can also do it easily with an IDE like IntelliJ.
 
+## Download the sample Gatling simulation
+
 {{< include download_samples.md >}}
 
 Extract the archive, then navigate to the sbt folder.
@@ -47,6 +49,8 @@ sbt test:assembly
 sbt will download the necessary dependencies and package our simulation.
 That's it, we created our first Gatling artifact!
 
+## Upload the artifact to FrontLine
+
 {{< include upload.md "frontline-samples/sbt/target/sbt-frontline-1.0.0.jar" >}}
 
 Upload it to FrontLine, either by drag-and-dropping it to the modal, or by clicking on the modal to open the file manager.
@@ -58,8 +62,18 @@ After a few seconds, the upload will be complete, and our artifact will be succe
 
 {{< img src="upload.png" alt="Start the upload" >}}
 
+## Create a FrontLine simulation
+
 {{< include simulation_1.md "frontline.sample.BasicSimulation" >}}
 
 {{< img src="create_simulation_step_1.png" alt="General configuration" >}}
 
 {{< include simulation_2.md "frontline.sample.BasicSimulation" >}}
+
+## Start load testing!
+
+{{< include run.md >}}
+
+## Additional resources
+
+{{< include resources.md >}}


### PR DESCRIPTION
Motivation:
- titles are missings because they are in included content

Modifications:
- there is no way for the toc to show titles in included content, so we need to put back the titles in the main page