### PR TITLE
Update external plugins link to current version

### DIFF
--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -12,4 +12,5 @@ cascade:
     gatlingSbtPluginVersion: "3.2.2"
     frontLineSbtPluginVersion: "1.3.2"
     frontLineGradlePluginVersion: "1.4.0"
+    externalPluginsVersion: "1.14.2"
 ---

--- a/content/reference/plugins/bamboo/index.md
+++ b/content/reference/plugins/bamboo/index.md
@@ -18,7 +18,7 @@ This plugin doesn't create a new Gatling FrontLine simulation, you have to creat
 To download the plugin, you need to get the jar file located at:
 
 ```
-https://downloads.gatling.io/releases/frontline-bamboo-plugin/1.13.3/frontline-bamboo-plugin-1.13.3.jar
+https://downloads.gatling.io/releases/frontline-bamboo-plugin/{{< var externalPluginsVersion >}}/frontline-bamboo-plugin-{{< var externalPluginsVersion >}}.jar
 ```
 
 You need to be connected as an administrator of your Bamboo application to install it. Go *Bamboo Administration*, *Manage Apps*, *Upload app*, and choose the jar file.

--- a/content/reference/plugins/grafana/index.md
+++ b/content/reference/plugins/grafana/index.md
@@ -16,7 +16,7 @@ Download and install [Grafana](http://grafana.org/download/).
 The FrontLine datasource for Grafana is packaged as a zip bundle that you can found at this URL:
 
 ```
-https://downloads.gatling.io/releases/frontline-grafana-bundle/1.13.3/frontline-grafana-bundle-1.13.3-bundle.zip
+https://downloads.gatling.io/releases/frontline-grafana-bundle/{{< var externalPluginsVersion >}}/frontline-grafana-bundle-{{< var externalPluginsVersion >}}-bundle.zip
 ```
 
 You can install it using the grafana-cli:

--- a/content/reference/plugins/jenkins/index.md
+++ b/content/reference/plugins/jenkins/index.md
@@ -18,7 +18,7 @@ This plugin doesn't create a new Gatling FrontLine simulation, you have to creat
 To download the plugin, you need to get the hpi file located at:
 
 ```
-https://downloads.gatling.io/releases/frontline-jenkins-plugin/1.13.3/frontline-jenkins-plugin-1.13.3.hpi
+https://downloads.gatling.io/releases/frontline-jenkins-plugin/{{< var externalPluginsVersion >}}/frontline-jenkins-plugin-{{< var externalPluginsVersion >}}.hpi
 ```
 
 You need to be connected as an administrator of your Jenkins application to install it. Go **Manage Jenkins**, **Manage Plugins**, **Advanced**, **Upload Plugin**, and choose the hpi file.

--- a/content/reference/plugins/script/index.md
+++ b/content/reference/plugins/script/index.md
@@ -27,4 +27,4 @@ You need to give 3 parameters to the script:
 
 ## Script
 
-It can be found [here](https://downloads.gatling.io/releases/frontline-ci-script/{{< var revnumber >}}/frontline-ci-script-{{< var revnumber >}}.zip)
+It can be found [here](https://downloads.gatling.io/releases/frontline-ci-script/{{< var externalPluginsVersion >}}/frontline-ci-script-{{< var externalPluginsVersion >}}.zip)

--- a/content/reference/plugins/teamcity/index.md
+++ b/content/reference/plugins/teamcity/index.md
@@ -18,7 +18,7 @@ This plugin doesn't create a new Gatling FrontLine simulation, you have to creat
 To download the plugin, you need to get the zip file located at:
 
 ```
-https://downloads.gatling.io/releases/frontline-teamcity-plugin/1.13.3/frontline-teamcity-plugin-1.13.3.zip
+https://downloads.gatling.io/releases/frontline-teamcity-plugin/{{< var externalPluginsVersion >}}/frontline-teamcity-plugin-{{< var externalPluginsVersion >}}.zip
 ```
 
 You need to be connected as an administrator of your TeamCity application to install it. Go **Administration**, **Plugins List**, **Upload plugin zip**, and choose the downloaded zip file.


### PR DESCRIPTION
Motivation:

- ci plugins and grafana datasource were still linking an old version: 1.13.3

Modification:

- added a constant with the version of the plugins
- use the constant in jenkins, bamboo, teamcity, script and grafana doc