### PR TITLE
Fix Hugo module init and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # FrontLine Cloud Documentation
 
-Node.js dependencies:
+## Prerequisites:
 
-Setup:
+You need [Go](https://golang.org/doc/install) and [Hugo](https://gohugo.io/getting-started/installing/) installed.
+
+## Setup:
 
 ```
 hugo mod get -u 
@@ -10,7 +12,7 @@ hugo mod npm pack
 npm install
 ```
 
-Development server:
+## Development server:
 
 ```
 hugo server -D --debug --baseURL="http://localhost:1313/docs/cloud/"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/gatling/frontline-cloud-doc
+
+go 1.16
+
+require github.com/gatling/gatling.io-doc-theme v0.0.0-20210802070358-35f196176960 // indirect


### PR DESCRIPTION
Motivation:
'hugo mod init' fails as-is and requires a workaround (removing the theme dependency).

Modifications:
Commit the go.mod file after successfully initializing the Hugo module. Also add the prerequisites to the readme file.

Result:
The commands mentioned in the readme should work as expected after checking out the repo.