### PR TITLE
doc: fix jobs deletion issue for private location on k8s

### DIFF
--- a/content/reference/admin/private_locations/kubernetes_deployment/index.md
+++ b/content/reference/admin/private_locations/kubernetes_deployment/index.md
@@ -33,7 +33,7 @@ rules:
     verbs: ["get", "create", "update", "delete"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create"]
+    verbs: ["create", "deletecollection"]
 ```
 
 ### Example
@@ -65,7 +65,7 @@ rules:
     verbs: ["get", "create", "update", "delete"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create"]
+    verbs: ["create", "deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Motivation:
Controlplane are not able to delete jobs, we waiting for TTL

Modifications:
Add deletecollection verbs on resources jobs in control-plane-role

Result:
Better doc for better world.