### PR TITLE
doc: optional field must be commented in example

### DIFF
--- a/content/reference/admin/private_locations/ec2_configuration/index.md
+++ b/content/reference/admin/private_locations/ec2_configuration/index.md
@@ -49,9 +49,9 @@ control-plane {
       # Subnets
       subnets = ["subnet-a", "subnet-b"]
       # Profile name (optional)
-      profile-name = ""
+      # profile-name = ""
       # IAM Instance profile (optional)
-      iam-instance-profile = ""
+      # iam-instance-profile = ""
       # Custom tags
       tags {
        # ExampleKey = ExampleValue


### PR DESCRIPTION
Motivation:
In AWS example, some optional field are set with empty values. It is confusing for the user.

Modifications:
Commented optional field

Result:
Better doc for better world