### PR TITLE
feat: introduce Docker images ARM support

### DIFF
--- a/content/reference/admin/private_locations/configuration/kubernetes/index.md
+++ b/content/reference/admin/private_locations/configuration/kubernetes/index.md
@@ -50,7 +50,7 @@ control-plane {
       # Custom image configuration
       # image {
       #   type = custom
-      #   image = gatlingcorp/classic-openjdk-x86:latest
+      #   image = "gatlingcorp/classic-openjdk:latest"
       # }
       # Clean up finished jobs resources after given time (optional)
       ttl-after-finished = 10 minutes


### PR DESCRIPTION
Shortening the image name as it now contains both supported architectures.

Note that the name MUST be quoted as ':' is considered a key:value
separator in HOCON.