### PR TITLE
chore: document jvm-options and jvm-home private locations configurations

### DIFF
--- a/content/reference/admin/private_locations/configuration/azure/index.md
+++ b/content/reference/admin/private_locations/configuration/azure/index.md
@@ -68,6 +68,26 @@ control-plane {
       # Use "subnets.name" as returned by Azure CLI:
       # az network vnet subnet list --resource-group MyResourceGroup --vnet-name MyVNet
       subnet-name = "default"
+      
+      # Java configuration (following configuration properties are optional)
+      # System properties (optional)
+      system-properties {
+        "java.net.preferIPv6Addresses" = "true"
+      }
+      # Overwrite JAVA_HOME definition (optional)
+      java-home = "/usr/lib/jvm/zulu17"
+      # JVM Options (optional)
+      # Default ones, that can be overriden with precedence:
+      # [
+      #   "-Xmx4G", 
+      #   "-XX:MaxInlineLevel=20", 
+      #   "-XX:MaxTrivialSize=12", 
+      #   "-XX:+IgnoreUnrecognizedVMOptions", 
+      #   "--add-opens=java.base/java.nio=ALL-UNNAMED", 
+      #   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
+      # ]
+      #  Based on your instance configuration, you may want to update Xmx and Xms values.
+      jvm-options = ["-Xmx8G", "-Xms512M"]
     }
   ]
 }

--- a/content/reference/admin/private_locations/configuration/ec2/index.md
+++ b/content/reference/admin/private_locations/configuration/ec2/index.md
@@ -78,7 +78,29 @@ control-plane {
           # ExampleKey = "ExampleValue"
         }
       }
+      
+      # Java configuration (following configuration properties are optional)
+      # System properties (optional)
+      system-properties {
+        "java.net.preferIPv6Addresses" = "true"
+      }
+      # Overwrite JAVA_HOME definition (optional)
+      java-home = "/usr/lib/jvm/zulu17"
+      # JVM Options (optional)
+      # Default ones, that can be overriden with precedence:
+      # [
+      #   "-Xmx4G", 
+      #   "-XX:MaxInlineLevel=20", 
+      #   "-XX:MaxTrivialSize=12", 
+      #   "-XX:+IgnoreUnrecognizedVMOptions", 
+      #   "--add-opens=java.base/java.nio=ALL-UNNAMED", 
+      #   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
+      # ]
+      #  Based on your instance configuration, you may want to update Xmx and Xms values.
+      jvm-options = ["-Xmx8G", "-Xms512M"]
     }
   ]
 }
 ```
+
+

--- a/content/reference/admin/private_locations/configuration/ec2/index.md
+++ b/content/reference/admin/private_locations/configuration/ec2/index.md
@@ -12,6 +12,11 @@ AWS private locations require the control plane to have access to AWS credential
 
 See [the AWS documentation for the Default Credential Provider Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).
 
+{{< alert warning >}}
+AWS EC2 private locations rely on [cloud-init](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) integration.
+If you configure a custom image, make sure it supports cloud-init.
+{{< /alert >}}
+
 ```bash
 control-plane {
   # Control plane token

--- a/content/reference/admin/private_locations/configuration/kubernetes/index.md
+++ b/content/reference/admin/private_locations/configuration/kubernetes/index.md
@@ -92,6 +92,26 @@ control-plane {
           effect = NoSchedule
         }
       ]
+      
+      # Java configuration (following configuration properties are optional)
+      # System properties (optional)
+      system-properties {
+        "java.net.preferIPv6Addresses" = "true"
+      }
+      # Overwrite JAVA_HOME definition (optional)
+      java-home = "/usr/lib/jvm/zulu17"
+      # JVM Options (optional)
+      # Default ones, that can be overriden with precedence:
+      # [
+      #   "-Xmx4G", 
+      #   "-XX:MaxInlineLevel=20", 
+      #   "-XX:MaxTrivialSize=12", 
+      #   "-XX:+IgnoreUnrecognizedVMOptions", 
+      #   "--add-opens=java.base/java.nio=ALL-UNNAMED", 
+      #   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
+      # ]
+      # Based on your instance configuration, you may want to update Xmx and Xms values.
+      jvm-options = ["-Xmx8G", "-Xms512M"]
     }
   ]
 }


### PR DESCRIPTION
[chore: document cloud-init reliance on Azure and AWS private locations](https://github.com/gatling/frontline-cloud-doc/commit/1f1ca874d6b4a3931df98351ceb2faf6e86f19b7)

[chore: document jvm-options and jvm-home private locations configurations](https://github.com/gatling/frontline-cloud-doc/commit/d10d5894d50d3b0e034bdd13b71690d3d62dd7fc) 

**Ref:** HYB-228