### PR TITLE
doc: add AWS elastic ips configuration, closes HYB-325

### DIFF
--- a/content/reference/admin/private_locations/configuration/ec2/index.md
+++ b/content/reference/admin/private_locations/configuration/ec2/index.md
@@ -54,6 +54,9 @@ control-plane {
       vpc = "vpc-a"
       # Subnets
       subnets = ["subnet-a", "subnet-b"]
+      # Elastic IP addresses (optional)
+      # You will only be able to deploy a number of load generators up to the number of Elastic IP addresses you have configured.
+      # elastic-ips = ["203.0.113.3", "203.0.113.4"]
       # Profile name (optional)
       # profile-name = ""
       # IAM Instance profile (optional)

--- a/content/reference/admin/private_locations/installation/ecs/index.md
+++ b/content/reference/admin/private_locations/installation/ecs/index.md
@@ -61,7 +61,9 @@ Select the policies:
         "ec2:CreateTags",
         "ec2:RunInstances",
         "ec2:TerminateInstance",
-        "iam:PassRole" <1>
+        "ec2.AssociateAddress", <1>
+        "ec2:DisassociateAddress", <1>
+        "iam:PassRole" <2>
       ],
       "Effect": "Allow",
       "Resource": "*"
@@ -70,7 +72,8 @@ Select the policies:
 }
 ```
 
-<1> Only required when setting an instance profile on Load Generators
+<1> Only required when setting elastic IP addresses on Load Generators
+<2> Only required when setting an instance profile on Load Generators
 
 If you have configured an IAM instance profile in the Control plane configuration file (with the optional key `iam-instance-profile`), you also need to add the `Action`s: `"iam:GetInstanceProfile"`, `"iam:ListInstanceProfiles"`, and `"iam:PassRole"`.
 

--- a/content/reference/admin/private_locations/installation/ecs/index.md
+++ b/content/reference/admin/private_locations/installation/ecs/index.md
@@ -60,6 +60,7 @@ Select the policies:
         "ec2:Describe*",
         "ec2:CreateTags",
         "ec2:RunInstances",
+        "ec2:TerminateInstance",
         "iam:PassRole" <1>
       ],
       "Effect": "Allow",


### PR DESCRIPTION
[doc: add missing AWS EC2 permission to terminate instances](https://github.com/gatling/frontline-cloud-doc/commit/713dc8a85b36e01062e42a83905fbadd4873985a)

[doc: add AWS elastic ips configuration, closes HYB-325](https://github.com/gatling/frontline-cloud-doc/commit/071e6f401ea02d6cd7850223001f1b4f5eea69ae)