### PR TITLE
fix: use universal zulu JAVA_HOME as default

### DIFF
--- a/content/reference/admin/private_locations/configuration/kubernetes/index.md
+++ b/content/reference/admin/private_locations/configuration/kubernetes/index.md
@@ -103,7 +103,7 @@ control-plane {
         "java.net.preferIPv6Addresses" = "true"
       }
       # Overwrite JAVA_HOME definition (optional)
-      java-home = "/usr/lib/jvm/zulu17"
+      java-home = "/usr/lib/jvm/zulu"
       # JVM Options (optional)
       # Default ones, that can be overriden with precedence:
       # [


### PR DESCRIPTION
Motivation:

- Demo path is wrong but at the same time commenting every optional parameter would make the configuration less readable (everything would be gray...)

Modification:

- JAVA_HOME is always /usr/lib/jvm/zulu

Result:

- Default configuration still works even if you forget to comment optional parameters