### PR TITLE
chore: updates to the kubernetes part documentation of private locations

### DIFF
--- a/content/reference/admin/private_locations/configuration/azure/index.md
+++ b/content/reference/admin/private_locations/configuration/azure/index.md
@@ -3,14 +3,16 @@ title: "Azure Load Generators"
 description: "Load Generators on your private Azure account"
 lead: "Private Locations on your Azure account"
 date: 2023-03-31T15:29:00+00:00
-lastmod: 2023-03-31T15:29:00+00:00
+lastmod: 2023-10-09T14:42:00+00:00
 weight: 22053
 ---
 
 ## Azure Virtual Machines
+
 Azure private locations require the control plane to have Azure credentials configured in order to instantiate virtual machines and associated resources.
 
 ### Environment variables
+
 Credentials can be set through environment variables in your control plane.
 
 | name                  | value             |
@@ -73,10 +75,10 @@ control-plane {
       # Java configuration (following configuration properties are optional)
       # System properties (optional)
       system-properties {
-        "java.net.preferIPv6Addresses" = "true"
+        # ExampleKey = ExampleValue
       }
       # Overwrite JAVA_HOME definition (optional)
-      java-home = "/usr/lib/jvm/zulu17"
+      # java-home = "/usr/lib/jvm/zulu"
       # JVM Options (optional)
       # Default ones, that can be overriden with precedence:
       # [
@@ -88,7 +90,7 @@ control-plane {
       #   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
       # ]
       #  Based on your instance configuration, you may want to update Xmx and Xms values.
-      jvm-options = ["-Xmx8G", "-Xms512M"]
+      # jvm-options = ["-Xmx4G", "-Xms512M"]
     }
   ]
 }

--- a/content/reference/admin/private_locations/configuration/ec2/index.md
+++ b/content/reference/admin/private_locations/configuration/ec2/index.md
@@ -3,11 +3,12 @@ title: "AWS EC2 Load Generators"
 description: "Load Generators on your private AWS account"
 lead: "Private Locations on your AWS account"
 date: 2023-01-12T16:46:04+00:00
-lastmod: 2023-01-12T16:29:04+00:00
-weight: 22052
+lastmod: 2023-10-09T14:42:00+00:00
+weight: 22053
 ---
 
 ## AWS EC2
+
 AWS private locations require the control plane to have access to AWS credentials from the default credential provider chain.
 
 See [the AWS documentation for the Default Credential Provider Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).
@@ -82,10 +83,10 @@ control-plane {
       # Java configuration (following configuration properties are optional)
       # System properties (optional)
       system-properties {
-        "java.net.preferIPv6Addresses" = "true"
+        # ExampleKey = "ExampleValue"
       }
       # Overwrite JAVA_HOME definition (optional)
-      java-home = "/usr/lib/jvm/zulu17"
+      # java-home = "/usr/lib/jvm/zulu"
       # JVM Options (optional)
       # Default ones, that can be overriden with precedence:
       # [
@@ -97,7 +98,7 @@ control-plane {
       #   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
       # ]
       #  Based on your instance configuration, you may want to update Xmx and Xms values.
-      jvm-options = ["-Xmx8G", "-Xms512M"]
+      # jvm-options = ["-Xmx4G", "-Xms512M"]
     }
   ]
 }
@@ -117,5 +118,3 @@ So when using a custom AMI, make sure following are available:
 {{< alert tip >}}
 Learn how to tune the OS for more performance, configure the open files limit, the kernel and the network [here](https://gatling.io/docs/gatling/reference/current/core/operations/).
 {{< /alert >}}
-
-

--- a/content/reference/admin/private_locations/configuration/kubernetes/index.md
+++ b/content/reference/admin/private_locations/configuration/kubernetes/index.md
@@ -3,7 +3,7 @@ title: "Kubernetes Load Generators"
 description: "Load Generators on your private Kubernetes cluster"
 lead: "Private Locations on your Kubernetes cluster"
 date: 2023-01-12T16:46:04+00:00
-lastmod: 2023-04-03T12:00:00+00:00
+lastmod: 2023-10-09T14:42:00+00:00
 weight: 22055
 ---
 
@@ -87,23 +87,23 @@ control-plane {
       }
       # Tolerations (optional)
       tolerations = [
-        {
-          key = key1
-          operator = Equal
-          # Value is not needed when effect is Exists (optional)
-          value = value1 
-          # An empty effect matches all effects with key (optional)
-          effect = NoSchedule
-        }
+      #  {
+      #    key = key1
+      #    operator = Equal
+      #    # Value is not needed when effect is Exists (optional)
+      #    value = value1 
+      #    # An empty effect matches all effects with key (optional)
+      #    effect = NoSchedule
+      #  }
       ]
       
       # Java configuration (following configuration properties are optional)
       # System properties (optional)
       system-properties {
-        "java.net.preferIPv6Addresses" = "true"
+        # ExampleKey = ExampleValue
       }
       # Overwrite JAVA_HOME definition (optional)
-      java-home = "/usr/lib/jvm/zulu"
+      # java-home = "/usr/lib/jvm/zulu"
       # JVM Options (optional)
       # Default ones, that can be overriden with precedence:
       # [
@@ -115,7 +115,7 @@ control-plane {
       #   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
       # ]
       # Based on your instance configuration, you may want to update Xmx and Xms values.
-      jvm-options = ["-Xmx8G", "-Xms512M"]
+      # jvm-options = ["-Xmx4G", "-Xms512M"]
     }
   ]
 }

--- a/content/reference/admin/private_locations/installation/kubernetes/index.md
+++ b/content/reference/admin/private_locations/installation/kubernetes/index.md
@@ -2,7 +2,7 @@
 title: "Kubernetes"
 description: "How to install a Gatling Control Plane on Kubernetes, to set up your Private Locations and run load generators in your own Kubernetes cluster"
 lead: "Run a Control Plane on Kubernetes, to set up your Private Locations and run load generators in your own Kubernetes network"
-lastmod: 2023-04-03T12:00:00+00:00
+lastmod: 2023-09-25T08:15:00+00:00
 weight: 22054
 ---
 
@@ -86,6 +86,7 @@ apiVersion: apps/v1
 kind: Deployment 
 metadata:
   name: control-plane
+  namespace: gatling
 spec:
   replicas: 1 
   selector: 


### PR DESCRIPTION
Motivation:

- Some defaults are "wrong" and/or confusing
- Defaults should be commented

Modification:

- Add missing namespace in Deployment example
- Comment optional configuration
- Change defaults of optional configuration (Xmx8G -> Xmx4G, etc.)