### PR TITLE
doc: GCP location missing documentation

### DIFF
--- a/content/reference/admin/private_locations/configuration/gcp/index.md
+++ b/content/reference/admin/private_locations/configuration/gcp/index.md
@@ -43,6 +43,9 @@ control-plane {
       # GCP location name, as listed by GCP CLI:
       # gcloud compute zones list
       zone = "europe-west3-a"
+      # Instance template (alternative to machine)
+      # instance-template = "example-template"
+      # Machine configuration (alternative to instance template)
       machine {
         # Virtual machine type, as listed by GCP CLI:
         # gcloud compute machine-types list --filter="zone:( europe-west3-a )"

--- a/content/reference/admin/private_locations/installation/gcp/index.md
+++ b/content/reference/admin/private_locations/installation/gcp/index.md
@@ -64,6 +64,14 @@ secretmanager.versions.access
 
 {{< img src="role-creation.png" alt="Role creation" >}}
 
+Some permissions may be required based on configuration:
+- `compute.images.useReadOnly` when using custom image
+- `compute.instanceTemplates.useReadOnly` for instance templates
+```
+compute.images.useReadOnly <1>
+compute.instanceTemplates.useReadOnly <2>
+compute.subnetworks.useExternalIp <3>
+```
 ## Service account creation
 
 In the GCP management console, open [Service accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) (or search for "Service Accounts" in the search bar). 


### PR DESCRIPTION
[doc: troubleshooting on GCP installation](https://github.com/gatling/frontline-cloud-doc/commit/3e6baf3f83992e0aff08d708617220084ad14f35)

[doc: permissions base on specific configuration](https://github.com/gatling/frontline-cloud-doc/commit/3341f44399af21a0691e1af6aa71dc0fbb01ed41)

[doc: add instance template to GCP location configuration](https://github.com/gatling/frontline-cloud-doc/commit/98bf3dc12b536dd4deb4c0fef026cfb1d5398c9b)