### PR TITLE
doc: references for Spot AWS private locations

### DIFF
--- a/content/reference/admin/private_locations/configuration/ec2/index.md
+++ b/content/reference/admin/private_locations/configuration/ec2/index.md
@@ -51,8 +51,6 @@ control-plane {
       security-groups = ["sg-mysecuritygroup"]
       # Instance type
       instance-type = "c5.xlarge"
-      # VPC
-      vpc = "vpc-a"
       # Spot instances (optional, default: false)
       # spot = true
       # Subnets

--- a/content/reference/admin/private_locations/configuration/ec2/index.md
+++ b/content/reference/admin/private_locations/configuration/ec2/index.md
@@ -53,6 +53,8 @@ control-plane {
       instance-type = "c5.xlarge"
       # VPC
       vpc = "vpc-a"
+      # Spot instances (optional, default: false)
+      # spot = true
       # Subnets
       subnets = ["subnet-a", "subnet-b"]
       # Elastic IP addresses (optional)


### PR DESCRIPTION
[doc: references for Spot AWS private locations](https://github.com/gatling/frontline-cloud-doc/commit/cc67e9a3ccc62f5cefbd3074066f4124f08083a7)

[doc: remove VPC configuration from AWS private locations](https://github.com/gatling/frontline-cloud-doc/commit/32a7ab4e29be092290bcbccfe6bd58993f506dff)