### PR TITLE
feat: add openapi

### DIFF
--- a/content/reference/user/api/index.md
+++ b/content/reference/user/api/index.md
@@ -5,6 +5,7 @@ lead: "Usage of the Gatling Enterprise public API"
 date: 2021-03-08T12:50:24+00:00
 lastmod: 2021-08-05T13:13:30+00:00
 weight: 21110
+toc: false
 ---
 
 The Gatling Enterprise API server also exposes a public API that you can use to trigger runs or fetch run results and metrics.
@@ -25,3 +26,5 @@ Some information before using the public API:
 - You have to provide the run ID as a query parameter to fetch other run metadata (load generators, remotes, hostnames, scenarios, groups, requests)
 - The `from` and `to` query parameters for the `/series` endpoint are the lower and upper timestamp bounds of the time window you want to query. You can fetch the total run time window from the `/runs` endpoint (`injectStart`, `injectEnd`).
 - The returned percentiles by the API are: min, p25, p50, p75, p80, p85, p90, p95, p99, p999, p9999 and max.
+
+{{< swagger-ui src="https://gatling.github.io/gatling-enterprise-api/openapi/openapi.yaml" >}}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gatling/frontline-cloud-doc
 
 go 1.18
 
-require github.com/gatling/gatling.io-doc-theme v0.0.0-20230921141656-1f0b1343432d // indirect
+require github.com/gatling/gatling.io-doc-theme v0.0.0-20231025122722-d2f24e06a131 // indirect


### PR DESCRIPTION
Motivation:
Publish public API documentation on public documentation site

Modifications:
 * Use the new swaggerui shortcode

Result:
OpenAPI documentation is publicly accessible and the user can try it

# Draft

Wait for gatling/gatling.io-doc-theme#29