### PR TITLE
Set the correct private_locations ECS installation IAM role action

### DIFF
--- a/content/reference/admin/private_locations/installation/ecs/index.md
+++ b/content/reference/admin/private_locations/installation/ecs/index.md
@@ -60,7 +60,7 @@ Select the policies:
         "ec2:Describe*",
         "ec2:CreateTags",
         "ec2:RunInstances",
-        "ec2:TerminateInstance",
+        "ec2:TerminateInstances",
         "ec2.AssociateAddress", <1>
         "ec2:DisassociateAddress", <1>
         "iam:PassRole" <2>


### PR DESCRIPTION
The IAM `Action`, `ec2:TerminateInstance`, is not a valid action.   `ec2:TerminateInstance` is the correct action.