### PR TITLE
doc: add load generators specs

### DIFF
--- a/content/reference/admin/private_locations/aws/configuration/index.md
+++ b/content/reference/admin/private_locations/aws/configuration/index.md
@@ -7,6 +7,20 @@ lastmod: 2023-10-13T08:10:39+00:00
 weight: 220311
 ---
 
+## Instance Specifications
+
+We recommend that you use for your own load generators instances with at least 4 cores.
+
+As Gatling load tests tend to be CPU bound, we recommend using instances of the "Compute Optimized" family.
+
+From our findings, it seems that Intel CPUs perform better than AMD and ARM Graviton ones when it comes to TLS.
+
+As a result, we recommend using `c6i.xlarge` instances or larger.
+
+You might want to tune the `Xmx` JVM options to half of the physical memory.
+See `jvm-options` configuration below.
+If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
+
 ## Permissions
 
 AWS private locations require the control plane to have access to AWS credentials from the default credential provider chain.

--- a/content/reference/admin/private_locations/azure/configuration/index.md
+++ b/content/reference/admin/private_locations/azure/configuration/index.md
@@ -7,6 +7,16 @@ lastmod: 2023-10-13T08:10:39+00:00
 weight: 220321
 ---
 
+## Instance Specifications
+
+We recommend that you use for your own load generators instances with at least 4 cores.
+
+As a result, we recommend using `Standard_A4_v2` instances or larger.
+
+You might want to tune the `Xmx` JVM options to half of the physical memory.
+See `jvm-options` configuration below.
+If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
+
 ## Permissions
 
 Azure private locations require the control plane to have credentials configured in order to instantiate virtual machines and associated resources.
@@ -66,7 +76,7 @@ control-plane {
       region = "westeurope"
       # Virtual machine size, as listed by Azure CLI:
       # az vm list-sizes --location "westeurope"
-      size = "Standard_A1"
+      size = "Standard_A4_v2"
       # Certified AMI configuration
       image {
         type = "certified"

--- a/content/reference/admin/private_locations/dedicated/configuration/index.md
+++ b/content/reference/admin/private_locations/dedicated/configuration/index.md
@@ -7,6 +7,14 @@ lastmod: 2023-10-13T08:10:39+00:00
 weight: 220361
 ---
 
+## Instance Specifications
+
+We recommend that you use instances with at least 4 cores for your own load generators.
+
+You might want to tune the `Xmx` JVM options to half of the physical memory.
+See `jvm-options` configuration below.
+If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
+
 ## Permissions
 
 You can configure private locations with pre-existing servers. 

--- a/content/reference/admin/private_locations/gcp/configuration/index.md
+++ b/content/reference/admin/private_locations/gcp/configuration/index.md
@@ -7,6 +7,18 @@ lastmod: 2023-10-13T08:10:39+00:00
 weight: 220331
 ---
 
+## Instance Specifications
+
+We recommend that you use for your own load generators instances with at least 4 cores.
+
+As Gatling load tests tend to be CPU bound, we recommend using instances of the "Compute Optimized" family.
+
+As a result, we recommend using `c3-highcpu-4` instances or larger.
+
+You might want to tune the `Xmx` JVM options to half of the physical memory.
+See `jvm-options` configuration below.
+If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
+
 ## Permissions
 
 GCP private locations require the control plane to have GCP access rights configured in order to instantiate virtual machines.
@@ -63,7 +75,7 @@ control-plane {
       machine {
         # Virtual machine type, as listed by GCP CLI:
         # gcloud compute machine-types list --filter="zone:( europe-west3-a )"
-        type = "e2-micro"
+        type = "c3-highcpu-4"
         # Configure load generators instances as preemptible or not. (optional, default: false)
         # preemptible = true
         # Certified image configuration

--- a/content/reference/admin/private_locations/introduction/index.md
+++ b/content/reference/admin/private_locations/introduction/index.md
@@ -29,15 +29,17 @@ The control plane will periodically poll our API gateway to find out if a new si
 If so, it will start new instances (based on the locations configurations) and start the simulation run on them. 
 Those instances will send stats through the API gateway as well.
 
+## Control plane
+
+### Network
+
 {{< alert info >}}
-Only two outbound domains must be allowed in your network:
-- The API Gateway: `https://api.gatling.io`
-- Download of the Gatling simulation on AWS S3:
+You network must allow the following outbound domains:
+- the Gatling Cloud API Gateway: `https://api.gatling.io`
+- The AWS S3 domains used to download Gatling libraries:
   - `https://cloud-probes-eu-west-3.s3.eu-west-3.amazonaws.com`
   - `https://frontline-cloud-prod-eu-west3.s3.eu-west-3.amazonaws.com`
 {{< /alert >}}
-
-## Control plane
 
 ### Token
 

--- a/content/reference/admin/private_locations/introduction/index.md
+++ b/content/reference/admin/private_locations/introduction/index.md
@@ -34,7 +34,7 @@ Those instances will send stats through the API gateway as well.
 ### Network
 
 {{< alert info >}}
-You network must allow the following outbound domains:
+Your network must allow the following outbound domains:
 - the Gatling Cloud API Gateway: `https://api.gatling.io`
 - The AWS S3 domains used to download Gatling libraries:
   - `https://cloud-probes-eu-west-3.s3.eu-west-3.amazonaws.com`

--- a/content/reference/admin/private_locations/kubernetes/configuration/index.md
+++ b/content/reference/admin/private_locations/kubernetes/configuration/index.md
@@ -7,6 +7,18 @@ lastmod: 2023-10-13T08:10:39+00:00
 weight: 220341
 ---
 
+## Instance Specifications
+
+We recommend that you use for your own load generators pods with at least 4 cores. See CPU requests and limits configuration below.
+
+You might want to tune the `Xmx` JVM options to half of the memory request.
+See `jvm-options` configuration below.
+If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
+
+Also, if you're deploying your load generators in the same cluster as the application under test,
+we recommend that you isolate the load generators on their dedicated nodes, using taints and tolerations.
+See `tolerations` configuration below.
+
 ## Permissions
 
 To use Kubernetes private locations, the control plane must have access to your Kubernetes cluster.


### PR DESCRIPTION
Motivations:

* we don't recommend instance specs, resulting in customers running load generators on instances with not enough CPU.
* the instance types we highly in our configuration samples are either small cheap one or deprecated

Modification:

* Add specs for Private Locations type
* Update config sample with instance types that make sense