### PR TITLE
doc: add documentation for Gatling as Code (sbt) and private locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,21 @@ npm install
 hugo server -D --debug --baseURL="http://localhost:1313/docs/cloud/"
 ```
 
+## Troubleshooting
+
+### Check theme version
+
+Theme version, defined in `go.mod`, should match a commit on Gatling theme [git repository](https://github.com/gatling/gatling.io-doc-theme/commits/main/) (`main` branch) :
+```
+require github.com/gatling/gatling.io-doc-theme v0.0.0-AAAMMJJHHmmSS-<first 12 chars of commit id>
+```
+
+### Update Hugo
+
+If you continue to encouter errors, check your installed Hugo version and update it if possible.
+
+Check [official documentation](https://gohugo.io/installation/linux/) for details.
+
+### Extract shortcode Error
+
 In case of issue such as `failed to extract shortcode: template for shortcode "img" not found`, run `hugo mod clean`.

--- a/content/tutorials/gac-sbt/index.md
+++ b/content/tutorials/gac-sbt/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Gatling as Code with Maven"
+title: "Gatling as Code with sbt"
 description: "Setup tutorial"
 lead: "Set up your project for automatic configuration of your simulation in Gatling Enterprise."
 date: 2024-01-31T18:30:00+02:00
@@ -9,32 +9,31 @@ private: true
 ---
 
 {{<alert tip>}}
-If you need a package to test this, you can use the following one: [`gatling-maven-plugin-demo-java`](https://github.com/gatling/gatling-maven-plugin-demo-java)
+If you need a package to test this, you can use the following one: [`gatling-sbt-plugin-demo`](https://github.com/gatling/gatling-sbt-plugin-demo)
 {{</alert>}}
 # Configuration
 
-## 1. Edit your `pom.xml` file
+## 1. Edit your `plugins.sbt` file
 
- * In `project.properties`, make sure you use the following version:
-   ```xml
-   <gatling-maven-plugin.version>4.8.0-M1</gatling-maven-plugin.version>
+ * In `addSbtPlugin`, make sure you use the following version:
+   ```scala
+   addSbtPlugin("io.gatling" % "gatling-sbt" % "4.8.0-M1")
    ```
 
 
 ## 2. Create your Gatling configuration
 
-Add a new directory at the root of your project: `.gatling` (sibling of your `pom.xml` file).
+Add a new directory at the module's `baseDir`: `.gatling`.
 
 Create a new file `.gatling/package.conf`.
 
 ```console
-.
+module-baseDir
 ├── .gatling/
 │   └── package.conf
-├── src/
-│   ├── main/
-│   └── test/
-└── pom.xml
+└── src/
+    ├── main/
+    └── test/
 ```
 
 This file is in [`HOCON` format (Human-Optimized Config Object Notation)](https://github.com/lightbend/config/blob/main/HOCON.md), which means you can also write `JSON` if you prefer.
@@ -120,33 +119,26 @@ gatling.enterprise {
 (package configuration, package upload, simulations configuration)
 
 {{<alert tip>}}
-Ensure you referenced the API token for your [maven extension](https://docs.gatling.io/gatling/reference/current/extensions/maven_plugin/#api-tokens).
+Ensure you referenced the API token for your [sbt plugin](https://docs.gatling.io/gatling/reference/current/extensions/sbt_plugin/#api-tokens).
 
 To create an API token: [documentation]({{<ref "../../reference/admin/api_tokens">}})
 (must have the **Configure** role).
 {{</alert>}}
 
-Use the following command when using Maven:
+Use the following command when using sbt:
 
-`mvn gatling:enterpriseUpload`
+`sbt Gatling / enterpriseUpload`
 
-Or the following if you’re using the provided wrapper:
-
-`./mvnw gatling:enterpriseUpload`
-
-A successful upload results in the following:
+A successful upload results in the following (here with demo project):
 
 ```bash
-[INFO] Package configuration file detected, applying it.
-[INFO] Package id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-[INFO] Package uploaded
-[INFO] Package successfully uploaded
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD SUCCESS
-[INFO] ------------------------------------------------------------------------
-[INFO] Total time:  x.xxx s
-[INFO] Finished at: yyyy-MM-ddThh:mm:ss+01:00
-[INFO] ------------------------------------------------------------------------
+sbt Gatling / enterpriseUpload
+[info] Generating Gatling Enterprise package <module-baseDir>/gatling-sbt-plugin-demo/target/gatling/gatling-sbt-plugin-demo-gatling-enterprise-<version>.jar
+[info] Package configuration file detected, applying it.
+[info] Package id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+[info] Package uploaded
+[success] Successfully upload package
+[success] Total time: x s, completed MMM dd, yyyy, hh:mm:ss
 ```
 
 If you encounter any problems, please contact our support team.

--- a/content/tutorials/gac-sbt/index.md
+++ b/content/tutorials/gac-sbt/index.md
@@ -17,7 +17,7 @@ If you need a package to test this, you can use the following one: [`gatling-sbt
 
  * In `addSbtPlugin`, make sure you use the following version:
    ```scala
-   addSbtPlugin("io.gatling" % "gatling-sbt" % "4.8.0-M1")
+   addSbtPlugin("io.gatling" % "gatling-sbt" % "4.8.0")
    ```
 
 

--- a/content/tutorials/gac-sbt/index.md
+++ b/content/tutorials/gac-sbt/index.md
@@ -38,6 +38,16 @@ module-baseDir
 
 This file is in [`HOCON` format (Human-Optimized Config Object Notation)](https://github.com/lightbend/config/blob/main/HOCON.md), which means you can also write `JSON` if you prefer.
 
+{{<alert tip>}}
+Managed location name must be an available region (see list in example file below).
+
+Private location name must be an id configured in your control plane ([see documentation]({{<ref "../../reference/admin/private_locations/introduction/#configuration">}})).
+{{</alert>}}
+
+{{<alert warning>}}
+Mixing managed and private locations is not supported by Gatling Enterprise. Ensure all your locations are either managed or private for a given simulation.
+{{</alert>}}
+
 ```bash
 gatling.enterprise {
   # The name of the package (Mandatory)
@@ -62,6 +72,10 @@ gatling.enterprise {
     # Locations configuration (mandatory)
     # Map of objects "key1" {...}, "key2" {...}, "key3"{...}
     locations {
+      # Mixing managed and private locations is not supported.
+      # Ensure all your locations are either managed or private for a given simulation.
+
+      # Managed location:
       # Configuration by region
       # Available regions:
       #  - "US West - N. California"
@@ -82,6 +96,17 @@ gatling.enterprise {
         ## (total sum of all locations MUST be 100 for a simulation)
         # weight = 100
       }
+
+      ## Private location:
+      ## The name must be an id configured in your control plane
+      
+      # "prl_example" {
+      #   # Amount of load generators in this location (mandatory)
+      #   size = 1
+      #   ## Weight of this location (optional)
+      #   ## (total sum of all locations MUST be 100 for a simulation)
+      #   # weight = 100
+      # }
     }
 
     # Configure specific parameters for this simulation (optional)

--- a/content/tutorials/gac/index.md
+++ b/content/tutorials/gac/index.md
@@ -39,6 +39,16 @@ Create a new file `.gatling/package.conf`.
 
 This file is in [`HOCON` format (Human-Optimized Config Object Notation)](https://github.com/lightbend/config/blob/main/HOCON.md), which means you can also write `JSON` if you prefer.
 
+{{<alert tip>}}
+Managed location name must be an available region (see list in example file below).
+
+Private location name must be an id configured in your control plane ([see documentation]({{<ref "../../reference/admin/private_locations/introduction/#configuration">}})).
+{{</alert>}}
+
+{{<alert warning>}}
+Mixing managed and private locations is not supported by Gatling Enterprise. Ensure all your locations are either managed or private for a given simulation.
+{{</alert>}}
+
 ```bash
 gatling.enterprise {
   # The name of the package (Mandatory)
@@ -63,6 +73,10 @@ gatling.enterprise {
     # Locations configuration (mandatory)
     # Map of objects "key1" {...}, "key2" {...}, "key3"{...}
     locations {
+      # Mixing managed and private locations is not supported.
+      # Ensure all your locations are either managed or private for a given simulation.
+
+      # Managed location:
       # Configuration by region
       # Available regions:
       #  - "US West - N. California"
@@ -83,6 +97,17 @@ gatling.enterprise {
         ## (total sum of all locations MUST be 100 for a simulation)
         # weight = 100
       }
+
+      ## Private location:
+      ## The name must be an id configured in your control plane
+      
+      # "prl_example" {
+      #   # Amount of load generators in this location (mandatory)
+      #   size = 1
+      #   ## Weight of this location (optional)
+      #   ## (total sum of all locations MUST be 100 for a simulation)
+      #   # weight = 100
+      # }
     }
 
     # Configure specific parameters for this simulation (optional)

--- a/content/tutorials/gac/index.md
+++ b/content/tutorials/gac/index.md
@@ -17,7 +17,7 @@ If you need a package to test this, you can use the following one: [`gatling-mav
 
  * In `project.properties`, make sure you use the following version:
    ```xml
-   <gatling-maven-plugin.version>4.8.0-M1</gatling-maven-plugin.version>
+   <gatling-maven-plugin.version>4.8.0</gatling-maven-plugin.version>
    ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gatling/frontline-cloud-doc
 
 go 1.21
 
-require github.com/gatling/gatling.io-doc-theme v0.0.0-20240201101243-7254d8d1a091 // indirect
+require github.com/gatling/gatling.io-doc-theme v0.0.0-20240201135435-0a089e04da41 // indirect


### PR DESCRIPTION
Notes :
- Both documentation pages are private (one needs the direct link to access it)
- I didn't change Maven page path, since a client may be using it at this moment (`/cloud/tutorials/gac/`)
- Thus, I created the sbt page in `/cloud/tutorials/gac-sbt/`

We (@Isammoc and I) chose to create separate pages to suit our immediate needs, but duplicated content is never a good thing. May we think about a tab component as for code (Java / Scala), but generalized for other contexts ? Like Maven / sbt / Gradle ? cc @notdryft 

![image](https://github.com/gatling/frontline-cloud-doc/assets/1850533/6f65a580-86c1-45f9-846c-3911e73b51cc)
